### PR TITLE
Make Restler work with Typo3 v9.5.4

### DIFF
--- a/Classes/System/TYPO3/Loader.php
+++ b/Classes/System/TYPO3/Loader.php
@@ -93,7 +93,7 @@ class Loader implements SingletonInterface
         }
 
         $bootstrapObj = Bootstrap::getInstance();
-        $bootstrapObj->loadExtensionTables(true);
+        //$bootstrapObj->loadExtensionTables(true);
         $bootstrapObj->initializeBackendUser();
         $bootstrapObj->initializeBackendAuthentication(true);
         $bootstrapObj->initializeLanguageObject();
@@ -140,7 +140,7 @@ class Loader implements SingletonInterface
             return;
         }
 
-        $GLOBALS['TT'] = new NullTimeTracker();
+        $GLOBALS['TT'] = new \TYPO3\CMS\Core\TimeTracker\TimeTracker(false);
 
         if ($this->isFrontEndUserInitialized === false) {
             $this->initializeFrontEndUser($pageId, $type);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.0",
         "typo3/cms-core": ">=9.0.0",
-        "luracast/restler": "3.0.0"
+        "luracast/restler": "3.0.0-RC6"
     },
     "require-dev": {
         "typo3/cms": "^7.6",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.0",
         "typo3/cms-core": ">=9.0.0",
-        "luracast/restler": "3.0.0.20190111"
+        "luracast/restler": "3.0.0"
     },
     "require-dev": {
         "typo3/cms": "^7.6",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "typo3/cms-core": ">=7.6.0",
+        "typo3/cms-core": ">=9.0.0",
         "luracast/restler": "3.0.0.20190111"
     },
     "require-dev": {


### PR DESCRIPTION
Changed the NullTimeTracker to a TimeTracker and bumped the requirements to v9